### PR TITLE
Fix rqt_dep for Noetic

### DIFF
--- a/src/rqt_dep/dotcode_pack.py
+++ b/src/rqt_dep/dotcode_pack.py
@@ -70,8 +70,8 @@ class RosPackageGraphDotcodeGenerator:
 
     def generate_dotcode(self,
                          dotcode_factory,
-                         selected_names=[],
-                         excludes=[],
+                         selected_names=None,
+                         excludes=None,
                          depth=3,
                          with_stacks=True,
                          descendants=True,
@@ -95,10 +95,14 @@ class RosPackageGraphDotcodeGenerator:
         :param show_system: if true, then system dependencies will be shown
         """
 
+        if selected_names is None:
+            selected_names = []
+        if excludes is None:
+            excludes = []
         # defaults
-        selected_names = filter(lambda x: x is not None and x != '', selected_names)
-        excludes = filter(lambda x: x is not None and x != '', excludes)
-        if selected_names is None or selected_names == []:
+        selected_names = [x for x in selected_names if x is not None and x != '']
+        excludes = [x for x in excludes if x is not None and x != '']
+        if not selected_names:
             selected_names = ['.*']
             self.depth = 1
         if depth is None:

--- a/src/rqt_dep/ros_pack_graph.py
+++ b/src/rqt_dep/ros_pack_graph.py
@@ -79,7 +79,7 @@ class StackageCompletionModel(QAbstractListModel):
 
     def __init__(self, linewidget, rospack, rosstack):
         super(StackageCompletionModel, self).__init__(linewidget)
-        self.allnames = sorted(list(set(rospack.list() + rosstack.list())))
+        self.allnames = sorted(list(set(list(rospack.list()) + list(rosstack.list()))))
         self.allnames = self.allnames + ['-%s' % name for name in self.allnames]
 
     def rowCount(self, parent):


### PR DESCRIPTION
Fixes https://github.com/ros-visualization/rqt_dep/issues/15.

It wasn't working because some changes between python2 and python3:

- As commented [here](https://github.com/ros-visualization/rqt_dep/issues/15#issuecomment-819527264), `RosPack.list()` and `RosStack.list()` aren't returning a `list` anymore.
  This change isn't needed if https://github.com/ros-infrastructure/rospkg/pull/220 is merged.
- `filter()` returns a filter object (I'm not sure what's the problem with that, but replacing it for a list comprehension fixed the bug :joy: )

I also did two extra changes:

- Not using `[]` in default arguments. I don't think it was a problem here, but just in case.
- Replacing `if selected_names is None or selected_names == []:` with the shorter `if not selected_names:`
